### PR TITLE
fix: base is missing / for github

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    base: "/developer",
+    base: "/developer/",
     title: "Reactive Markets Developer",
     description: "Develop for the Reactive Markets Platform",
     head: [


### PR DESCRIPTION
The base is needed when hosting at a subdomain.