### PR TITLE
fix: correcting icon urls for github

### DIFF
--- a/docs/.vuepress/public/manifest.json
+++ b/docs/.vuepress/public/manifest.json
@@ -3,12 +3,12 @@
     "short_name": "Reactive",
     "icons": [
         {
-            "src": "/icon-192.png",
+            "src": "/developer/icon-192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/icon-512.png",
+            "src": "/developer/icon-512.png",
             "sizes": "512x512",
             "type": "image/png"
         }


### PR DESCRIPTION
The url needs /developer infront of it.