### PR TITLE
fix: add trailing / to start_url in manifest

### DIFF
--- a/docs/.vuepress/public/manifest.json
+++ b/docs/.vuepress/public/manifest.json
@@ -17,5 +17,5 @@
     "background_color": "#000",
     "display": "standalone",
     "orientation": "portrait-primary",
-    "start_url": "/developer"
+    "start_url": "/developer/"
 }


### PR DESCRIPTION
The start_url needs to match the base in config.